### PR TITLE
fix a VisualStudio design time error (again)

### DIFF
--- a/WinAppSdkCleaner/ViewModels/MainWindowViewModel.cs
+++ b/WinAppSdkCleaner/ViewModels/MainWindowViewModel.cs
@@ -2,12 +2,12 @@
 
 namespace WinAppSdkCleaner.ViewModels;
 
-internal sealed class ViewModel
+internal sealed class MainWindowViewModel
 {
     public string SdkTabHeading { get; init; }
     public ImageSource WindowIcon { get; init; }
 
-    public ViewModel()
+    public MainWindowViewModel()
     {
         if (IntegrityLevel.IsElevated())
         {
@@ -17,7 +17,7 @@ internal sealed class ViewModel
         else
         {
             SdkTabHeading = "_User Scope";
-            WindowIcon = BitmapFrame.Create(new Uri("pack://application:,,,/resources/app.ico"));
+            WindowIcon = BitmapFrame.Create(new Uri("pack://application:,,,/resources/normal.ico"));
         }
     }
 }

--- a/WinAppSdkCleaner/Views/MainWindow.xaml
+++ b/WinAppSdkCleaner/Views/MainWindow.xaml
@@ -4,7 +4,6 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:WinAppSdkCleaner.Views"
-        xmlns:vm="clr-namespace:WinAppSdkCleaner.ViewModels"
         mc:Ignorable="d"
         Title="Windows Application Sdk Cleaner"
         Width="650"
@@ -14,10 +13,6 @@
         FontSize="{StaticResource FontSizeNormal}"
         ResizeMode="CanResizeWithGrip"
         Icon="{Binding WindowIcon}">
-
-    <Window.DataContext>
-        <vm:ViewModel/>
-    </Window.DataContext>
 
     <Grid>
         <TabControl Focusable="False">

--- a/WinAppSdkCleaner/Views/MainWindow.xaml.cs
+++ b/WinAppSdkCleaner/Views/MainWindow.xaml.cs
@@ -12,6 +12,8 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
 
+        DataContext = new ViewModels.MainWindowViewModel();
+
         SourceInitialized += (s, a) =>
         {
             if (Settings.Data.IsFirstRun)


### PR DESCRIPTION
Properly this time. Just don't let VS know about the window's data context, then it can't fail to find the resource. Change that view models file name as well while I'm up to it.