### PR TITLE
Use the latest dependencies when removing

### DIFF
--- a/WinAppSdkCleaner/ViewModels/SdkViewModel.cs
+++ b/WinAppSdkCleaner/ViewModels/SdkViewModel.cs
@@ -41,6 +41,10 @@ internal class SdkViewModel : INotifyPropertyChanged
     {
         try
         {
+            // guarantee the latest dependencies are used, a store
+            // application may have been installed in the background
+            await ExecuteSearch(); 
+
             IEnumerable<PackageRecord> packages = sdkList.GetDistinctSelectedPackages();
 
             if (packages.Any())


### PR DESCRIPTION
If a store app has been installed in the background, removal of the sdk that it depends on would fail, unless the dependencies are updated before removal.