### PR TITLE
Remove disabling caption button window

### DIFF
--- a/WinAppSdkCleaner/NativeMethods.txt
+++ b/WinAppSdkCleaner/NativeMethods.txt
@@ -12,6 +12,4 @@ GetCursorPos
 ScreenToClient
 WM_SYSCOMMAND
 GetDoubleClickTime
-FindWindowEx
-EnableWindow
 WM_NCHITTEST

--- a/WinAppSdkCleaner/Views/ContentDialogHelper.cs
+++ b/WinAppSdkCleaner/Views/ContentDialogHelper.cs
@@ -38,7 +38,6 @@ internal class ContentDialogHelper
 
         currentDialog = dialog;
         currentDialog.Opened += CurrentDialog_Opened;
-        currentDialog.Closing += ContentDialog_Closing;
         currentDialog.Closed += ContentDialog_Closed;
         currentDialog.Loaded += CurrentDialog_Loaded;
 
@@ -48,23 +47,7 @@ internal class ContentDialogHelper
         currentDialog.RequestedTheme = ((FrameworkElement)parentWindow.Content).ActualTheme;
         currentDialog.FlowDirection = ((FrameworkElement)parentWindow.Content).FlowDirection;
 
-        EnableCaptionButtons(enable: false);
-
         return await currentDialog.ShowAsync();
-    }
-
-    private void EnableCaptionButtons(bool enable)
-    {
-        // clearing the caption button regions using inputNonClientPointerSource.ClearRegionRects(NonClientRegionKind.Close)
-        // etc. will initially disable the buttons but if the window is moved the regions will be automatically set again.
-        
-        HWND hWnd = PInvoke.FindWindowEx(parentWindow.WindowHandle, HWND.Null, "InputNonClientPointerSource", null);
-        Debug.Assert(!hWnd.IsNull);
-
-        if (!hWnd.IsNull)
-        {
-            PInvoke.EnableWindow(hWnd, enable);
-        }
     }
 
     private static void CurrentDialog_Loaded(object sender, RoutedEventArgs e)
@@ -76,11 +59,6 @@ internal class ContentDialogHelper
             // no lightweight styling, and size 20 is a bit loud
             contentControl.FontSize = 18;
         }
-    }
-
-    private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
-    {
-        EnableCaptionButtons(enable: true);
     }
 
     private void ContentDialog_Closed(ContentDialog sender, ContentDialogClosedEventArgs args)

--- a/WinAppSdkCleaner/Views/MainWindow.cs
+++ b/WinAppSdkCleaner/Views/MainWindow.cs
@@ -346,16 +346,17 @@ internal sealed partial class MainWindow : Window
 
         try
         {
+            RectInt32 windowRect = new RectInt32(0, 0, AppWindow.ClientSize.Width, AppWindow.ClientSize.Height);
+
             if (ContentDialogHelper.IsContentDialogOpen)
             {
-                RectInt32 windowRect = new RectInt32(0, 0, AppWindow.ClientSize.Width, AppWindow.ClientSize.Height);
+                // this also effectively disables the caption buttons
                 inputNonClientPointerSource.SetRegionRects(NonClientRegionKind.Passthrough, [windowRect]);
             }
             else if ((Content is FrameworkElement layoutRoot) && layoutRoot.IsLoaded && AppWindowTitleBar.IsCustomizationSupported())
             {
                 // as there is no clear distinction any more between the title bar region and the client area,
                 // just treat the whole window as a title bar, click anywhere on the backdrop to drag the window.
-                RectInt32 windowRect = new RectInt32(0, 0, AppWindow.ClientSize.Width, AppWindow.ClientSize.Height);
                 inputNonClientPointerSource.SetRegionRects(NonClientRegionKind.Caption, [windowRect]);
 
                 List<RectInt32> rects = new List<RectInt32>(cInitialCapacity);
@@ -367,8 +368,7 @@ internal sealed partial class MainWindow : Window
         }
         catch (Exception ex)
         {
-            // accessing Window.Content can throw an object closed exception when
-            // a menu unloaded event fires because the window is closing
+            // accessing Window.Content can throw an object closed exception
             Debug.WriteLine(ex);
         }
     }


### PR DESCRIPTION
A side effect of setting the passthrough area to cover the whole window means it's not required anymore